### PR TITLE
Password fetching from Vault, along w/ required CLI updates

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -304,9 +304,8 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 			if usingVault {
 				if usedVault {
 					utils.Fatalf("Vault passwords only support unlocking one account, it looks like you are trying to unlock %v.", len(accounts))
-				} else {
-					usedVault = true
 				}
+				usedVault = true
 			}
 		}
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -375,7 +375,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 		} else if usingMakerPassword {
 			passwd = append(passwd, ctx.GlobalString(utils.VoteBlockMakerAccountPasswordFlag.Name))
 		} else {
-			utils.Fatalf("Tried to unlock a voter account, but no password was provided via --blockmakerpassword or Vault password.")
+			utils.Fatalf("Tried to unlock a blockmaker account, but no password was provided via --blockmakerpassword or Vault password.")
 		}
 
 		unlockAccount(ctx, accman, addr, 0, passwd)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -325,6 +325,9 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 	)
 	usingVoterAcct := ctx.GlobalIsSet(utils.VoteAccountFlag.Name)
 	usingBlockMakerAcct := ctx.GlobalIsSet(utils.VoteBlockMakerAccountFlag.Name)
+	if usingBlockMakerAcct && usingVoterAcct {
+		utils.Fatalf("Provided with both `voteaccount` and `blockmakeraccount` flags, only one of these should be set at a time.")
+	}
 	if len(accounts) == 0 && !usingVoterAcct && !usingBlockMakerAcct {
 		utils.Fatalf("Was not provided an `unlock`, `voteaccount`, or `blockmakeraccount` flag, cannot launch.")
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -328,9 +328,6 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 	if usingBlockMakerAcct && usingVoterAcct {
 		utils.Fatalf("Provided with both `voteaccount` and `blockmakeraccount` flags, only one of these should be set at a time.")
 	}
-	if len(accounts) == 0 && !usingVoterAcct && !usingBlockMakerAcct {
-		utils.Fatalf("Was not provided an `unlock`, `voteaccount`, or `blockmakeraccount` flag, cannot launch.")
-	}
 	var addr string
 	if usingVoterAcct {
 		addr = strings.TrimSpace(ctx.GlobalString(utils.VoteAccountFlag.Name))

--- a/cmd/geth/passwords.go
+++ b/cmd/geth/passwords.go
@@ -31,11 +31,12 @@ func fetchPasswordFromVault(ctx *cli.Context) (string, error) {
 		}
 		vaultClient.SetToken(token)
 
-		// Perform the query to retrieve the password value
+		// Perform the query to retrieve the password value, then clear token for safety
 		vault := vaultClient.Logical()
 		fullSecretPath := "/" + ctx.GlobalString(utils.VaultPrefixFlag.Name) +
 			"/" + ctx.GlobalString(utils.VaultPasswordPathFlag.Name)
 		secret, err := vault.Read(fullSecretPath)
+		vaultClient.ClearToken()
 		if err != nil {
 			log.Fatal(err)
 			return "", err
@@ -86,13 +87,16 @@ func usingVaultPassword(ctx *cli.Context) bool {
 		return true
 	case 1:
 		// Bad case, have one but missing another, throw an error
-		// and let 'em know what's missing
+		// and let 'em know what's missing. Return statement is to
+		// keep compiler quiet -- fxn would never return from this fatal case.
 		utils.Fatalf("Some Vault flags specified, but not enough to retrieve the password; please include: %v", missingFlags)
 		return true
 	case 2:
 		// Vanilla case, as two of these have default values
 		return false
 	default:
+		// Return statement is to keep compiler quiet -- fxn would
+		// never return from this fatal case.
 		utils.Fatalf("Unexpected number of Vault args missing, two of four should always be specified via defaults.")
 		return false
 	}
@@ -119,6 +123,7 @@ func loginAws(v *vaultAPI.Client) (string, error) {
 	// Login data args are left empty so that Vault's AWSAuth implementation
 	// knows to let AWS's EnvProvider handle it.  The EnvProvider searches the
 	// environment for these values: https://github.com/aws/aws-sdk-go/blob/master/aws/credentials/env_provider.go
+	// The args all get their own line so the linter doesn't reshuffle quotes & comments
 	loginData, err := awsauth.GenerateLoginData(
 		/*accessKey=*/ "",
 		/*secretKey=*/ "",

--- a/cmd/geth/passwords.go
+++ b/cmd/geth/passwords.go
@@ -14,27 +14,6 @@ import (
 	awsauth "github.com/hashicorp/vault/builtin/credential/aws"
 )
 
-func fetchPassword(ctx *cli.Context) (string, error) {
-	if usingVaultPassword(ctx) {
-		return fetchPasswordFromVault(ctx)
-	}
-	return fetchPasswordFromCLI(ctx)
-}
-
-func fetchPasswordFromCLI(ctx *cli.Context) (string, error) {
-	accountPass := strings.TrimSpace(ctx.GlobalString(utils.VoteAccountPasswordFlag.Name))
-	blockPass := strings.TrimSpace(ctx.GlobalString(utils.VoteBlockMakerAccountPasswordFlag.Name))
-	if accountPass != "" {
-		return accountPass, nil
-	} else if blockPass != "" {
-		return blockPass, nil
-	} else {
-		utils.Fatalf("Looked for password via fetchPasswordFromCLI, but no plaintext password arguments found.")
-		// Program exits before this return, only required to quiet down compiler
-		return "", nil
-	}
-}
-
 func fetchPasswordFromVault(ctx *cli.Context) (string, error) {
 	if usingVaultPassword(ctx) {
 		// Authenticate to Vault via the AWS method

--- a/cmd/geth/passwords.go
+++ b/cmd/geth/passwords.go
@@ -70,8 +70,6 @@ func fetchPasswordFromVault(ctx *cli.Context) (string, error) {
 	return "", nil
 }
 
-func cliVal(ctx *cli.Context)
-
 func usingVaultPassword(ctx *cli.Context) bool {
 	passwordFlags := map[cli.StringFlag]string{
 		utils.VoteAccountPasswordFlag:           strings.TrimSpace(ctx.GlobalString(utils.VoteAccountPasswordFlag.Name)),

--- a/cmd/geth/passwords.go
+++ b/cmd/geth/passwords.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	cli "gopkg.in/urfave/cli.v1"
+
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	vaultAPI "github.com/hashicorp/vault/api"
+	awsauth "github.com/hashicorp/vault/builtin/credential/aws"
+)
+
+func fetchPassword(ctx *cli.Context) (string, error) {
+	if usingVaultPassword(ctx) {
+		return fetchPasswordFromVault(ctx)
+	}
+	return fetchPasswordFromCLI(ctx)
+}
+
+func fetchPasswordFromCLI(ctx *cli.Context) (string, error) {
+	accountPass := strings.TrimSpace(ctx.GlobalString(utils.VoteAccountPasswordFlag.Name))
+	blockPass := strings.TrimSpace(ctx.GlobalString(utils.VoteBlockMakerAccountPasswordFlag.Name))
+	if accountPass != "" {
+		return accountPass, nil
+	} else if blockPass != "" {
+		return blockPass, nil
+	} else {
+		utils.Fatalf("Looked for password via fetchPasswordFromCLI, but no plaintext password arguments found.")
+		// Program exits before this return, only required to quiet down compiler
+		return "", nil
+	}
+}
+
+func fetchPasswordFromVault(ctx *cli.Context) (string, error) {
+	if usingVaultPassword(ctx) {
+		// Authenticate to Vault via the AWS method
+		vaultConfig := vaultAPI.DefaultConfig()
+		vaultConfig.Address = ctx.GlobalString(utils.VaultAddrFlag.Name)
+		vaultClient, err := vaultAPI.NewClient(vaultConfig)
+		token, err := loginAws(vaultClient)
+		if err != nil {
+			log.Fatal(err)
+			return "", err
+		}
+		vaultClient.SetToken(token)
+
+		// Perform the query to retrieve the password value
+		vault := vaultClient.Logical()
+		fullSecretPath := "/" + ctx.GlobalString(utils.VaultPrefixFlag.Name) +
+			"/" + ctx.GlobalString(utils.VaultPasswordPathFlag.Name)
+		secret, err := vault.Read(fullSecretPath)
+		if err != nil {
+			log.Fatal(err)
+			return "", err
+		}
+
+		// Extract from response & return to caller
+		keyname := ctx.GlobalString(utils.VaultPasswordNameFlag.Name)
+		password, present := secret.Data[keyname]
+		if !present {
+			utils.Fatalf("fetchPasswordFromVault found a secret at specified path (%v), but secret did not contain specified key name (%v). Secret was : %v", fullSecretPath, keyname, secret.Data)
+		}
+		return password.(string), nil
+	}
+	utils.Fatalf("fetchPasswordFromVault called even though CLI got a password argument.")
+	return "", nil
+}
+
+func cliVal(ctx *cli.Context)
+
+func usingVaultPassword(ctx *cli.Context) bool {
+	passwordFlags := map[cli.StringFlag]string{
+		utils.VoteAccountPasswordFlag:           strings.TrimSpace(ctx.GlobalString(utils.VoteAccountPasswordFlag.Name)),
+		utils.VoteBlockMakerAccountPasswordFlag: strings.TrimSpace(ctx.GlobalString(utils.VoteBlockMakerAccountPasswordFlag.Name)),
+		utils.PasswordFileFlag:                  strings.TrimSpace(ctx.GlobalString(utils.PasswordFileFlag.Name)),
+	}
+	setPassFlags := make([]string, 0)
+	for flag, val := range passwordFlags {
+		if val != "" {
+			setPassFlags = append(setPassFlags, flag.Name)
+		}
+	}
+	if len(setPassFlags) > 0 {
+		if len(setPassFlags) == 1 {
+			return false
+		}
+		utils.Fatalf("Too many (%v) password flags have been set.  Only one of the following should be supplied: %v", len(setPassFlags), setPassFlags)
+		return false
+	} else {
+		vaultFlags := map[cli.StringFlag]string{
+			utils.VaultAddrFlag:         strings.TrimSpace(ctx.GlobalString(utils.VaultAddrFlag.Name)),
+			utils.VaultPrefixFlag:       strings.TrimSpace(ctx.GlobalString(utils.VaultPrefixFlag.Name)),
+			utils.VaultPasswordNameFlag: strings.TrimSpace(ctx.GlobalString(utils.VaultPasswordNameFlag.Name)),
+			utils.VaultPasswordPathFlag: strings.TrimSpace(ctx.GlobalString(utils.VaultPasswordPathFlag.Name)),
+		}
+		missingFlags := make([]string, 0)
+		for flag, val := range vaultFlags {
+			if val == "" {
+				missingFlags = append(missingFlags, flag.Name)
+			}
+		}
+		if len(missingFlags) > 0 {
+			utils.Fatalf("No account password specified, but missing flags required for retrieving password from Vault.  Please supply: %v", missingFlags)
+		}
+		return true
+	}
+}
+
+// Expects to be running in EC2
+func getIAMRole() (string, error) {
+	svc := ec2metadata.New(session.New())
+	iam, err := svc.IAMInfo()
+	if err != nil {
+		return "", err
+	}
+	// Our instance profile conveniently has the same name as the role
+	profile := iam.InstanceProfileArn
+	splitArn := strings.Split(profile, "/")
+	if len(splitArn) < 2 {
+		return "", fmt.Errorf("no / character found in instance profile ARN")
+	}
+	role := splitArn[1]
+	return role, nil
+}
+
+func loginAws(v *vaultAPI.Client) (string, error) {
+	loginData, err := awsauth.GenerateLoginData("", "", "", "")
+	if err != nil {
+		return "", err
+	}
+	if loginData == nil {
+		return "", fmt.Errorf("got nil response from GenerateLoginData")
+	}
+
+	role, err := getIAMRole()
+	if err != nil {
+		return "", err
+	}
+	loginData["role"] = role
+
+	path := "auth/aws/login"
+
+	secret, err := v.Logical().Write(path, loginData)
+	if err != nil {
+		return "", err
+	}
+	if secret == nil {
+		return "", fmt.Errorf("empty response from credential provider")
+	}
+	if secret.Auth == nil {
+		return "", fmt.Errorf("auth secret has no auth data")
+	}
+
+	token := secret.Auth.ClientToken
+	return token, nil
+}

--- a/cmd/geth/passwords.go
+++ b/cmd/geth/passwords.go
@@ -119,7 +119,12 @@ func loginAws(v *vaultAPI.Client) (string, error) {
 	// Login data args are left empty so that Vault's AWSAuth implementation
 	// knows to let AWS's EnvProvider handle it.  The EnvProvider searches the
 	// environment for these values: https://github.com/aws/aws-sdk-go/blob/master/aws/credentials/env_provider.go
-	loginData, err := awsauth.GenerateLoginData( /*accessKey=*/ "" /*secretKey=*/, "" /*sessionToken=*/, "" /*headerValue=*/, "")
+	loginData, err := awsauth.GenerateLoginData(
+		/*accessKey=*/ "",
+		/*secretKey=*/ "",
+		/*sessionToken=*/ "",
+		/*headerValue=*/ "",
+	)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -97,6 +97,15 @@ var AppHelpFlagGroups = []flagGroup{
 		},
 	},
 	{
+		Name: "VAULT",
+		Flags: []cli.Flag{
+			utils.VaultAddrFlag,
+			utils.VaultPrefixFlag,
+			utils.VaultPasswordPathFlag,
+			utils.VaultPasswordNameFlag,
+		},
+	},
+	{
 		Name: "RAFT",
 		Flags: []cli.Flag{
 			utils.RaftModeFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -389,6 +389,27 @@ var (
 		Usage: "Path of thr constellation private config",
 		Value: "",
 	}
+	// Vault flags
+	VaultAddrFlag = cli.StringFlag{
+		Name:  "vaultaddr",
+		Usage: "Web address to a Hashicorp Vault installation holding passwords",
+		Value: "",
+	}
+	VaultPrefixFlag = cli.StringFlag{
+		Name:  "vaultprefix",
+		Usage: "Prefix where the Vault KV engine is mounted, no outer slashes. Canonically set to `quorum` in Eximchain",
+		Value: "quorum",
+	}
+	VaultPasswordPathFlag = cli.StringFlag{
+		Name:  "vaultpasswordpath",
+		Usage: "Vault path to where password is kept within KV engine.  No leading slash, does not include the engine's mount prefix",
+		Value: "",
+	}
+	VaultPasswordNameFlag = cli.StringFlag{
+		Name:  "vaultpasswordname",
+		Usage: "Key name within KV store where password is kept. Canonically set to `geth_pw` in Eximchain",
+		Value: "geth_pw",
+	}
 	// Raft flags
 	RaftModeFlag = cli.BoolFlag{
 		Name:  "raft",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -386,28 +386,28 @@ var (
 	}
 	PrivateConfigPathFlag = cli.StringFlag{
 		Name:  "privateconfigpath",
-		Usage: "Path of thr constellation private config",
+		Usage: "Path of the constellation private config",
 		Value: "",
 	}
 	// Vault flags
 	VaultAddrFlag = cli.StringFlag{
 		Name:  "vaultaddr",
-		Usage: "Web address to a Hashicorp Vault installation holding passwords",
+		Usage: "DNS or IP address where a Hashicorp Vault server holding passwords can be reached. If set, vaultpasswordpath must also be set, and you should ensure that you can use the vaultprefix and vaultpasswordname default values. Vault password fetching only works when geth is running in an EC2 instance.",
 		Value: "",
 	}
 	VaultPrefixFlag = cli.StringFlag{
 		Name:  "vaultprefix",
-		Usage: "Prefix where the Vault KV engine is mounted, no outer slashes. Canonically set to `quorum` in Eximchain",
+		Usage: "Prefix where the Vault KV engine is mounted, no outer slashes. Canonically set to `quorum` in Eximchain. Vault password fetching only works when geth is running in an EC2 instance.",
 		Value: "quorum",
 	}
 	VaultPasswordPathFlag = cli.StringFlag{
 		Name:  "vaultpasswordpath",
-		Usage: "Vault path to where password is kept within KV engine.  No leading slash, does not include the engine's mount prefix",
+		Usage: "Vault path to where password is kept within KV engine.  No leading slash, does not include the engine's mount prefix. If set, vaultaddr must also be set, and you should ensure that you can use the vaultprefix and vaultpasswordname default values. Vault password fetching only works when geth is running in an EC2 instance.",
 		Value: "",
 	}
 	VaultPasswordNameFlag = cli.StringFlag{
 		Name:  "vaultpasswordname",
-		Usage: "Key name within KV store where password is kept. Canonically set to `geth_pw` in Eximchain",
+		Usage: "Key name within KV store where password is kept. Canonically set to `geth_pw` in Eximchain. Vault password fetching only works when geth is running in an EC2 instance.",
 		Value: "geth_pw",
 	}
 	// Raft flags


### PR DESCRIPTION
This has all been tested with the private transaction loop, although y'all might want to run it again on your own machines to confirm for yourselves.

## Motivation
Rather than passing passwords in plaintext from the command line, we want to:
- Get the password's name and location in a Vault server/engine from the CLI
- Use Vault's AWS auth method to sign into the Vault server
- Retrieve the password and use it to unlock the specific account.

## Change Summary
- **main.go** - Modifies the `startNode` method to first check if we're using a password file, and if not, sends password fetching to our new module.  Adds various safety checks to determine what type of node we're trying to spin up.  Minor refactor of how maker/voter accounts are unlocked.
- **passwords.go** - Handles password fetching in all cases: 
  - Checks the provided arguments to determine whether we're using a Vault password (i.e. all required Vault args are present)
  - If we aren't, looks for a plaintext password arg and throws an error if not present
  - If we are, uses the [tx-executor AWS login functions](https://github.com/Eximchain/eximchain-transaction-executor/blob/e237250ced19a1ba860d215a7e79872d6fa913ae/main.go#L38) @Lsquared13 wrote to sign in and then fetch the password
- **flags.go** & **usage.go** - Adds the four new Vault CLI args and hooks their documentation into the built-in help functions.

## Gotchas
- **Assumption** - Safety checks assume that every running instance of this code will be either a maker, voter, or observer, and that some account type must always be passed in.  I was under the impression that was true and added a safety check to be certain, but thought I should point it out to confirm.
- **Degradation** - The built-in `unlock` argument supports unlocking multiple accounts, while this password fetching implementation only supports one password.  We decided fetching multiple passwords was unnecessary for our current problems, but something worth nothing.