### PR TITLE
EIP155 compliant signed transaction can now be used within quorum.

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -228,7 +228,8 @@ func SignEthereum(data []byte, prv *ecdsa.PrivateKey) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	sig[64] += 27 // as described in the yellow paper
+	sig[64] += 37 //We changed the default v value to reflect the eip155 spec of
+	// so by default v is now 37
 	return sig, err
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1223,12 +1223,25 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 	return submitTransaction(ctx, s.b, tx, signature, isPrivate)
 }
 
+func checkRLP(ctx context.Content, encodedTx string) (*types.TransactionNew, bool) {
+	txNew := new(types.TransactionNew)
+	if err := rlp.DecodeBytes(common.FromHex(encodedTx), txNew); err != nil {
+		return txNew, false
+	}
+	return txNew, true
+}
+
 // SendRawTransaction will add the signed transaction to the transaction pool.
 // The sender is responsible for signing the transaction and using the correct nonce.
 func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encodedTx string) (string, error) {
+	txNew, rlpStatus := checkRLP(ctx, encodedTx)
 	tx := new(types.Transaction)
-	if err := rlp.DecodeBytes(common.FromHex(encodedTx), tx); err != nil {
-		return "", err
+	if rlpStatus {
+		tx = txNew.ConvertTransaction()
+	} else {
+		if err := rlp.DecodeBytes(common.FromHex(encodedTx), tx); err != nil {
+			return "", err
+		}
 	}
 
 	if err := s.b.SendTx(ctx, tx); err != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1223,7 +1223,7 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 	return submitTransaction(ctx, s.b, tx, signature, isPrivate)
 }
 
-func checkRLP(ctx context.Content, encodedTx string) (*types.TransactionNew, bool) {
+func checkRLP(ctx context.Context, encodedTx string) (*types.TransactionNew, bool) {
 	txNew := new(types.TransactionNew)
 	if err := rlp.DecodeBytes(common.FromHex(encodedTx), txNew); err != nil {
 		return txNew, false


### PR DESCRIPTION
There is also a spec change regarding how private and public transactions work. Before quorum used v values of 37 and 38 for private transactions but because that conflicts with how EIP 155 signers work, we are now using 27 and 28 for private transactions and the regular 37 and 38 for public transactions. This should not conflict because our network is completely new and so we do not have to worry about any backwards compatibility issues.